### PR TITLE
Fix crash when all apps using the virtualcam close

### DIFF
--- a/src/common/CoreMediaIO/DeviceAbstractionLayer/Devices/Sample/Assistant/Server/CMIO_DPA_Sample_Server_Assistant.cpp
+++ b/src/common/CoreMediaIO/DeviceAbstractionLayer/Devices/Sample/Assistant/Server/CMIO_DPA_Sample_Server_Assistant.cpp
@@ -248,11 +248,6 @@ namespace CMIO { namespace DPA { namespace Sample { namespace Server
 		// If there are still clients connected to the Assistant, simply return
 		if (not mClientInfoMap.empty())
 			return;
-			
-		// There are no more clients, so exit the SampleAssistant server process.
-		// The "com.apple.cmio.DPA.Sample" service will still be registered with the bootstrap_look_up mechanism, so the next time a client needs to establish a connection it will
-		// cause the SampleAssistant server process to be restarted.
-		exit(0);
 	}
 
 	#pragma mark -


### PR DESCRIPTION
@lsamayoa [figured it out](https://github.com/lsamayoa/obs-mac-virtualcam/commit/3c8de5ff9035c01b303fcd74d05bb28a1906049d)! Seems so obvious in retrospect, I wonder why the crash stacktrace didn't make it obvious what was happening!

Some vary basic initial testing makes it seem that this fixes #1.