### PR TITLE
Nightly builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout obs-studio
+      uses: actions/checkout@v2
+      with:
+        repository: obsproject/obs-studio
+        path: obs-studio
+        submodules: recursive
+        ref: 25.0.7
+
+    - name: Checkout obs-mac-virtualcam
+      uses: actions/checkout@v2
+      with:
+        path: obs-mac-virtualcam
+
+    - name: Install OBS deps
+      run: |
+        brew install FFmpeg x264 Qt5 cmake mbedtls swig
+
+    - name: Build OBS
+      run: |
+        mkdir obs-studio/build
+        cd obs-studio/build
+
+        export QTDIR=/usr/local/opt/qt 
+        cmake ..
+        make -j
+
+    - name: Build the plugin
+      run: |
+        mkdir obs-mac-virtualcam/build
+        cd obs-mac-virtualcam/build
+
+        cmake -DLIBOBS_INCLUDE_DIR:STRING=$GITHUB_WORKSPACE/obs-studio/libobs -DLIBOBS_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/libobs/libobs.dylib -DOBS_FRONTEND_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/UI/obs-frontend-api/libobs-frontend-api.dylib -DQTDIR:STRING=/usr/local/opt/qt ..
+        make -j
+
+    - uses: actions/upload-artifact@v1
+      with:
+        name: obs-mac-virtualcam
+        path: obs-mac-virtualcam/build/src

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,13 @@ jobs:
         cmake -DLIBOBS_INCLUDE_DIR:STRING=$GITHUB_WORKSPACE/obs-studio/libobs -DLIBOBS_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/libobs/libobs.dylib -DOBS_FRONTEND_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/UI/obs-frontend-api/libobs-frontend-api.dylib -DQTDIR:STRING=/usr/local/opt/qt ..
         make -j
 
+    - name: Copy artifacts
+      run: |
+        mkdir artifacts
+        cp -r obs-mac-virtualcam/build/src/dal-plugin/obs-mac-virtualcam.plugin artifacts/
+        cp obs-mac-virtualcam/build/src/obs-plugin/obs-mac-virtualcam.so artifacts/
+
     - uses: actions/upload-artifact@v1
       with:
-        name: obs-mac-virtualcam
-        path: obs-mac-virtualcam/build/src
+        name: build-artifacts
+        path: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,11 +46,23 @@ jobs:
 
     - name: Copy artifacts
       run: |
-        mkdir artifacts
-        cp -r obs-mac-virtualcam/build/src/dal-plugin/obs-mac-virtualcam.plugin artifacts/
-        cp obs-mac-virtualcam/build/src/obs-plugin/obs-mac-virtualcam.so artifacts/
+        mkdir -p artifacts/dal-plugin
+        mkdir -p artifacts/obs-plugin
+
+        cp -r obs-mac-virtualcam/build/src/dal-plugin/obs-mac-virtualcam.plugin artifacts/dal-plugin/
+        cp obs-mac-virtualcam/build/src/obs-plugin/obs-mac-virtualcam.so artifacts/obs-plugin/
 
     - uses: actions/upload-artifact@v1
       with:
-        name: build-artifacts
+        name: obs-mac-virtualcam
         path: artifacts
+
+    - uses: actions/upload-artifact@v1
+      with:
+        name: obs-mac-virtualcam-dal-plugin
+        path: artifacts/dal-plugin
+
+    - uses: actions/upload-artifact@v1
+      with:
+        name: obs-mac-virtualcam-obs-plugin
+        path: artifacts/obs-plugin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,17 @@ jobs:
         cmake -DLIBOBS_INCLUDE_DIR:STRING=$GITHUB_WORKSPACE/obs-studio/libobs -DLIBOBS_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/libobs/libobs.dylib -DOBS_FRONTEND_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/UI/obs-frontend-api/libobs-frontend-api.dylib -DQTDIR:STRING=/usr/local/opt/qt ..
         make -j
 
+    - name: Fix runtime QT deps
+      run: |
+        install_name_tool \
+          -change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets \
+            @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets \
+          -change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui \
+            @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui \
+          -change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore \
+            @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore \
+          obs-mac-virtualcam/build/src/obs-plugin/obs-mac-virtualcam.so
+
     - name: Copy artifacts
       run: |
         mkdir -p artifacts/dal-plugin


### PR DESCRIPTION
Hey there,

First of all, thank you for your amazing work. I've had no major issues with this plugin as-is so far.
I developed some OBS plugins in the past and for me it was always a huge deal having to download its source and dependencies (I have a low-end mac which is always running low on disk space), so I came up with this simple workflow using Github Actions to automatically build your plugin when pushing to master (I used it myself instead of building the plugin locally).

It probably does need some polishing (maybe bundle an install script with the library files), but I think it's a good starting point. My guess is that most interested users might not be familiar with building software at all, so providing the binaries may help them. I'm building them against 25.0.7 (latest macOS release until now).

This pipeline generates three artifacts on Github: one containing both the DAL plugin and OBS plugin, and two others containing the individual plugins. The DAL plugin must be copied to `/Library/CoreMediaIO/Plug-Ins/DAL` (as usual) and the OBS plugin must be copied to `/Library/Application Support/obs-studio/plugins/obs-mac-virtualcam/bin`.