### PR TITLE
NEW: Include RingCentral in list of compatible apps.

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -15,5 +15,6 @@ Please note that this list is not complete.
 |Safari|No (?)|
 |Slack|No (?)|
 |Amazon Chime|Yes(?)*|
+|RingCentral|Yes|
 
 *May not always work. If it doesn't, please take a look at [this](https://github.com/johnboiles/obs-mac-virtualcam/issues/4) issue


### PR DESCRIPTION
As above. RingCentral tested OK.
High Sierra, MacBook Pro 2011