### PR TITLE
Attempt building for macOS 10.14 Mojave

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,3 +46,26 @@ jobs:
           -DOBS_FRONTEND_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/UI/obs-frontend-api/libobs-frontend-api.dylib \
           -DQTDIR:STRING=/usr/local/opt/qt ..
         make -j
+
+    - name: Fix runtime QT deps
+      run: |
+        install_name_tool \
+          -change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets \
+            @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets \
+          -change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui \
+            @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui \
+          -change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore \
+            @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore \
+          obs-mac-virtualcam/build/src/obs-plugin/obs-mac-virtualcam.so
+
+    - name: Copy artifacts
+      run: |
+        mkdir -p artifacts
+
+        cp -r obs-mac-virtualcam/build/src/dal-plugin/obs-mac-virtualcam.plugin artifacts/
+        cp obs-mac-virtualcam/build/src/obs-plugin/obs-mac-virtualcam.so artifacts/
+
+    - uses: actions/upload-artifact@v1
+      with:
+        name: raw-plugins
+        path: artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
         cd obs-studio/build
 
         export QTDIR=$(brew --prefix qt5)
+        export MACOSX_DEPLOYMENT_TARGET=10.14
         cmake ..
         make -j
 
@@ -39,6 +40,7 @@ jobs:
         mkdir obs-mac-virtualcam/build
         cd obs-mac-virtualcam/build
 
+        export MACOSX_DEPLOYMENT_TARGET=10.14
         cmake -DLIBOBS_INCLUDE_DIR:STRING=$GITHUB_WORKSPACE/obs-studio/libobs \
           -DLIBOBS_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/libobs/libobs.dylib \
           -DOBS_FRONTEND_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/UI/obs-frontend-api/libobs-frontend-api.dylib \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   build:
+    env:
+      MACOSX_DEPLOYMENT_TARGET: 10.14
     runs-on: macos-latest
 
     steps:
@@ -31,7 +33,6 @@ jobs:
         cd obs-studio/build
 
         export QTDIR=$(brew --prefix qt5)
-        export MACOSX_DEPLOYMENT_TARGET=10.14
         cmake ..
         make -j
 
@@ -40,7 +41,6 @@ jobs:
         mkdir obs-mac-virtualcam/build
         cd obs-mac-virtualcam/build
 
-        export MACOSX_DEPLOYMENT_TARGET=10.14
         cmake -DLIBOBS_INCLUDE_DIR:STRING=$GITHUB_WORKSPACE/obs-studio/libobs \
           -DLIBOBS_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/libobs/libobs.dylib \
           -DOBS_FRONTEND_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/UI/obs-frontend-api/libobs-frontend-api.dylib \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   build:
+    env:
+      MACOSX_DEPLOYMENT_TARGET: 10.14
     runs-on: macos-latest
 
     steps:
@@ -36,7 +38,6 @@ jobs:
         cd obs-studio/build
 
         export QTDIR=$(brew --prefix qt5)
-        export MACOSX_DEPLOYMENT_TARGET=10.14
         cmake ..
         make -j
 
@@ -45,7 +46,6 @@ jobs:
         mkdir obs-mac-virtualcam/build
         cd obs-mac-virtualcam/build
 
-        export MACOSX_DEPLOYMENT_TARGET=10.14
         cmake -DLIBOBS_INCLUDE_DIR:STRING=$GITHUB_WORKSPACE/obs-studio/libobs \
           -DLIBOBS_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/libobs/libobs.dylib \
           -DOBS_FRONTEND_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/UI/obs-frontend-api/libobs-frontend-api.dylib \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
         cd obs-studio/build
 
         export QTDIR=$(brew --prefix qt5)
+        export MACOSX_DEPLOYMENT_TARGET=10.14
         cmake ..
         make -j
 
@@ -44,6 +45,7 @@ jobs:
         mkdir obs-mac-virtualcam/build
         cd obs-mac-virtualcam/build
 
+        export MACOSX_DEPLOYMENT_TARGET=10.14
         cmake -DLIBOBS_INCLUDE_DIR:STRING=$GITHUB_WORKSPACE/obs-studio/libobs \
           -DLIBOBS_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/libobs/libobs.dylib \
           -DOBS_FRONTEND_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/UI/obs-frontend-api/libobs-frontend-api.dylib \


### PR DESCRIPTION
This is a bit of a shot in the dark, but it may be that we just need to set an environment variable to configure building for an older version of macOS. See https://github.com/johnboiles/obs-mac-virtualcam/issues/85#issuecomment-628298465