### PR TITLE
Comment out debugging lines that give compile errors on macOS 10.13 and XCode 10.1

### DIFF
--- a/src/dal-plugin/ObjectStore.mm
+++ b/src/dal-plugin/ObjectStore.mm
@@ -86,8 +86,9 @@
             return @"kCMIODevicePropertyCanSwitchFrameRatesWithoutFrameDrops";
         case kCMIODevicePropertyLocation:
             return @"kCMIODevicePropertyLocation";
-        case kCMIODevicePropertyDeviceHasStreamingError:
-            return @"kCMIODevicePropertyDeviceHasStreamingError";
+        // The next one gives errors on macOS 10.13 High Sierra and XCode 10.1
+        // case kCMIODevicePropertyDeviceHasStreamingError:
+        //     return @"kCMIODevicePropertyDeviceHasStreamingError";
         case kCMIODevicePropertyScopeInput:
             return @"kCMIODevicePropertyScopeInput";
         case kCMIODevicePropertyScopeOutput:


### PR DESCRIPTION
This fixes the compile error mentioned in https://github.com/johnboiles/obs-mac-virtualcam/issues/85#issuecomment-628397413. With this change, I can compile this plugin and it works (e.g., I can see the output of the virtual camera in quicktime).
