### PR TITLE
Fixing QuickTime recording

### DIFF
--- a/src/dal-plugin/CMSampleBufferUtils.h
+++ b/src/dal-plugin/CMSampleBufferUtils.h
@@ -10,3 +10,5 @@
 OSStatus CMSampleBufferCreateFromData(NSSize size, CMSampleTimingInfo timingInfo, UInt64 sequenceNumber, NSData *data, CMSampleBufferRef *sampleBuffer);
 
 OSStatus CMSampleBufferCreateFromDataNoCopy(NSSize size, CMSampleTimingInfo timingInfo, UInt64 sequenceNumber, NSData *data, CMSampleBufferRef *sampleBuffer);
+
+CMSampleTimingInfo CMSampleTimingInfoForTimestamp(uint64_t timestampNanos, double fps);

--- a/src/dal-plugin/CMSampleBufferUtils.mm
+++ b/src/dal-plugin/CMSampleBufferUtils.mm
@@ -119,3 +119,18 @@ OSStatus CMSampleBufferCreateFromDataNoCopy(NSSize size, CMSampleTimingInfo timi
 
     return noErr;
 }
+
+CMSampleTimingInfo CMSampleTimingInfoForTimestamp(uint64_t timestampNanos, double fps) {
+    // The timing here is quite important. For frames to be delivered correctly and successfully be recorded by apps
+    // like QuickTime Player, we need to be accurate in both our timestamps _and_ have a sensible scale. Using large
+    // timestamps and scales like mach_absolute_time() and NSEC_PER_SEC will work for display, but will error out
+    // when trying to record.
+    //
+    // 600 is a commmon default in Apple's docs https://developer.apple.com/documentation/avfoundation/avmutablemovie/1390622-timescale
+    CMTimeScale scale = 600;
+    CMSampleTimingInfo timing;
+    timing.duration = CMTimeMake(scale, fps * scale);
+    timing.presentationTimeStamp = CMTimeMake((timestampNanos / (double)NSEC_PER_SEC) * scale, scale);
+    timing.decodeTimeStamp = kCMTimeInvalid;
+    return timing;
+}


### PR DESCRIPTION
Closes #91 and hopefully fixes some other apps too that are sensitive to timestamp issues.

Thanks to @mizt's solution in https://github.com/johnboiles/coremediaio-dal-minimal-example/pull/13