### PR TITLE
Add inspector for aspect ratio mismatches

### DIFF
--- a/src/obs-plugin/plugin-main.mm
+++ b/src/obs-plugin/plugin-main.mm
@@ -100,13 +100,6 @@ void start()
     obs_data_release(settings);
 }
 
-static string knownResolutions[] = {
-    "640x360",
-    "1280x720",
-    "1920x1080"
-};
-
-bool isUsualResolution(obs_video_info ovi);
 string getAspectRatio(int width, int height);
 bool obs_module_load(void)
 {
@@ -140,25 +133,6 @@ bool obs_module_load(void)
                     return;
                 }
             }
-            if(!isUsualResolution(ovi)) {
-                QMessageBox msgBox;
-                msgBox.setText(QString::fromStdString(obs_module_text("Warning: Unusual resolution")));
-                stringstream stream;
-                stream << obs_module_text("Your output resolution (");
-                stream << ovi.output_width << "x" << ovi.output_height;
-                stream << obs_module_text(") is unusual which may result in a distorted image. If that is the case, use one of the following resolutions:\n");
-                for(string res : knownResolutions){
-                    stream << res << endl;
-                }
-                stream << obs_module_text("Continue anyways?");
-                msgBox.setInformativeText(QString::fromStdString(stream.str()));
-                msgBox.setStandardButtons(QMessageBox::Yes);
-                msgBox.addButton(QMessageBox::No);
-                msgBox.setDefaultButton(QMessageBox::No);
-                if(msgBox.exec() != QMessageBox::Yes){
-                    return;
-                }
-            }
             action->setText(obs_module_text("Stop Virtual Camera"));
             obs_output_start(output);
         }
@@ -170,15 +144,6 @@ bool obs_module_load(void)
     start();
     
     return true;
-}
-
-bool isUsualResolution(obs_video_info ovi){
-    string res = to_string(ovi.output_width) + "x" + to_string(ovi.output_height);
-    for(string knownRes : knownResolutions){
-        if (res == knownRes)
-            return true;
-    }
-    return false;
 }
 
 int gcd(int a, int b) {

--- a/src/obs-plugin/plugin-main.mm
+++ b/src/obs-plugin/plugin-main.mm
@@ -123,7 +123,7 @@ bool obs_module_load(void)
             
             obs_video_info ovi;
             obs_get_video_info(&ovi);
-            if(getAspectRatio(ovi.base_width, ovi.base_height)!=getAspectRatio(ovi.output_width, ovi.output_height)) {
+            if(getAspectRatio(ovi.base_width, ovi.base_height) != getAspectRatio(ovi.output_width, ovi.output_height)) {
                 QMessageBox msgBox;
                 msgBox.setText(QString::fromStdString(obs_module_text("Warning: Aspect ratios don't match")));
                 stringstream stream;
@@ -159,11 +159,8 @@ bool obs_module_load(void)
                     return;
                 }
             }
-            
             action->setText(obs_module_text("Stop Virtual Camera"));
             obs_output_start(output);
-    
-        
         }
     };
     action->connect(action, &QAction::triggered, menu_cb);
@@ -178,21 +175,21 @@ bool obs_module_load(void)
 bool isUsualResolution(obs_video_info ovi){
     string res = to_string(ovi.output_width) + "x" + to_string(ovi.output_height);
     for(string knownRes : knownResolutions){
-        if (res==knownRes)
+        if (res == knownRes)
             return true;
     }
     return false;
 }
 
-int gcd(int a, int b);
+int gcd(int a, int b) {
+    if (b == 0) {
+      return a;
+    }
+   return gcd(b, a % b);
+}
+
 string getAspectRatio(int width, int height){
     int baseGcd = gcd(width, height);
     string aspectRatio = to_string(width/baseGcd) + ":" + to_string(height/baseGcd);
     return aspectRatio;
-}
-
-int gcd(int a, int b) {
-   if (b == 0)
-      return a;
-   return gcd(b, a % b);
 }


### PR DESCRIPTION
Add inspector for unusual resolutions and differing aspect ratios when starting the virtual camera.
It tells the user when his output resolution is unusual and user his aspect ratios don't match; both issues may result in cropped / distorted images.

Addresses #135, but doesn't really fix it.