### PR TITLE
Fix for weird resolutions (fixes #135)

### DIFF
--- a/src/obs-plugin/plugin-main.mm
+++ b/src/obs-plugin/plugin-main.mm
@@ -74,6 +74,10 @@ static void virtualcam_output_raw_video(void *data, struct video_data *frame)
     CGFloat width = ovi.output_width;
     CGFloat height = ovi.output_height;
     uint8_t *outData = frame->data[0];
+    if (frame->linesize[0] != (ovi.output_width * 2)) {
+        blog(LOG_ERROR, "VIRTUALCAM unexpected frame->linesize (expected:%d actual:%d)", (ovi.output_width * 2), frame->linesize[0]);
+    }
+
     [sMachServer sendFrameWithSize:NSMakeSize(width, height) timestamp:frame->timestamp frameBytes:outData];
 }
 


### PR DESCRIPTION
With help from this [SO post](https://stackoverflow.com/questions/46879895/byte-per-row-is-wrong-when-creating-a-cvpixelbuffer-with-width-multiple-of-90) I was able to track down the distortion issue to CVPixelBuffers getting created with different widths then expected. This change will do a line-by-line copy if the CVPixelBuffer has a different size than the OBS framebuffer.

Fixes #135