### PR TITLE
Don't crash when changing resolutions and starting/stopping

### DIFF
--- a/src/obs-plugin/MachServer.mm
+++ b/src/obs-plugin/MachServer.mm
@@ -13,6 +13,7 @@
 @interface MachServer () <NSPortDelegate>
 @property NSPort *port;
 @property NSMutableSet *clientPorts;
+@property NSRunLoop *runLoop;
 @end
 
 
@@ -23,6 +24,13 @@
         self.clientPorts = [[NSMutableSet alloc] init];
     }
     return self;
+}
+
+- (void)dealloc {
+    blog(LOG_DEBUG, "VIRTUALCAM tearing down MachServer");
+    [self.runLoop removePort:self.port forMode:NSDefaultRunLoopMode];
+    [self.port invalidate];
+    self.port.delegate = nil;
 }
 
 - (void)run {
@@ -49,8 +57,8 @@
 
     self.port.delegate = self;
 
-    NSRunLoop *runLoop = [NSRunLoop currentRunLoop];
-    [runLoop addPort:self.port forMode:NSDefaultRunLoopMode];
+    self.runLoop = [NSRunLoop currentRunLoop];
+    [self.runLoop addPort:self.port forMode:NSDefaultRunLoopMode];
 
     blog(LOG_DEBUG, "VIRTUALCAM mach server running!");
 }

--- a/src/obs-plugin/plugin-main.mm
+++ b/src/obs-plugin/plugin-main.mm
@@ -36,6 +36,7 @@ static void *virtualcam_output_create(obs_data_t *settings, obs_output_t *output
 static void virtualcam_output_destroy(void *data)
 {
     blog(LOG_DEBUG, "VIRTUALCAM output_destroy");
+    sMachServer = nil;
 }
 
 
@@ -92,14 +93,6 @@ struct obs_output_info virtualcam_output_info = {
     .raw_video = virtualcam_output_raw_video,
 };
 
-void start()
-{
-    OBSData settings;
-    
-    output = obs_output_create("virtualcam_output", "virtualcam_output", settings, NULL);
-    obs_data_release(settings);
-}
-
 bool obs_module_load(void)
 {
     blog(LOG_DEBUG, "VIRTUALCAM obs_module_load");
@@ -111,17 +104,18 @@ bool obs_module_load(void)
         if (obs_output_active(output)) {
             action->setText(obs_module_text("Start Virtual Camera"));
             obs_output_stop(output);
+            obs_output_release(output);
+            output = NULL;
         } else {
             action->setText(obs_module_text("Stop Virtual Camera"));
+            OBSData settings;
+            output = obs_output_create("virtualcam_output", "virtualcam_output", settings, NULL);
             obs_output_start(output);
         }
     };
     action->connect(action, &QAction::triggered, menu_cb);
 
     obs_register_output(&virtualcam_output_info);
-
-    start();
-    
     return true;
 }
 


### PR DESCRIPTION
Fixes #83 and #45 I think.

On closer inspection of the [Decklink output plugin](https://github.com/obsproject/obs-studio/blob/19701e3bbc45d9a6eeccecaac40d6e6d2fa1abf0/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp#L70) in the OBS repo it looks like it creates and destroys the output every time it is started/stopped. This patch adapts this plugin to do the same and also adapts the Mach server code so that it can be destroyed and recreated gracefully.

Tested locally with QuickTime and it looks like I can change resolution, and start/stop as many times as I want and it works.