### PR TITLE
Send FPS from OBS to the DAL plugin

### DIFF
--- a/src/dal-plugin/CMSampleBufferUtils.h
+++ b/src/dal-plugin/CMSampleBufferUtils.h
@@ -11,4 +11,4 @@ OSStatus CMSampleBufferCreateFromData(NSSize size, CMSampleTimingInfo timingInfo
 
 OSStatus CMSampleBufferCreateFromDataNoCopy(NSSize size, CMSampleTimingInfo timingInfo, UInt64 sequenceNumber, NSData *data, CMSampleBufferRef *sampleBuffer);
 
-CMSampleTimingInfo CMSampleTimingInfoForTimestamp(uint64_t timestampNanos, double fps);
+CMSampleTimingInfo CMSampleTimingInfoForTimestamp(uint64_t timestampNanos, uint32_t fpsNumerator, uint32_t fpsDenominator);

--- a/src/dal-plugin/CMSampleBufferUtils.mm
+++ b/src/dal-plugin/CMSampleBufferUtils.mm
@@ -137,7 +137,7 @@ OSStatus CMSampleBufferCreateFromDataNoCopy(NSSize size, CMSampleTimingInfo timi
     return noErr;
 }
 
-CMSampleTimingInfo CMSampleTimingInfoForTimestamp(uint64_t timestampNanos, double fps) {
+CMSampleTimingInfo CMSampleTimingInfoForTimestamp(uint64_t timestampNanos, uint32_t fpsNumerator, uint32_t fpsDenominator) {
     // The timing here is quite important. For frames to be delivered correctly and successfully be recorded by apps
     // like QuickTime Player, we need to be accurate in both our timestamps _and_ have a sensible scale. Using large
     // timestamps and scales like mach_absolute_time() and NSEC_PER_SEC will work for display, but will error out
@@ -146,7 +146,7 @@ CMSampleTimingInfo CMSampleTimingInfoForTimestamp(uint64_t timestampNanos, doubl
     // 600 is a commmon default in Apple's docs https://developer.apple.com/documentation/avfoundation/avmutablemovie/1390622-timescale
     CMTimeScale scale = 600;
     CMSampleTimingInfo timing;
-    timing.duration = CMTimeMake(scale, fps * scale);
+    timing.duration = CMTimeMake(fpsDenominator * scale, fpsNumerator * scale);
     timing.presentationTimeStamp = CMTimeMake((timestampNanos / (double)NSEC_PER_SEC) * scale, scale);
     timing.decodeTimeStamp = kCMTimeInvalid;
     return timing;

--- a/src/dal-plugin/MachClient.h
+++ b/src/dal-plugin/MachClient.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol MachClientDelegate
 
-- (void)receivedFrameWithSize:(NSSize)size timestamp:(uint64_t)timestamp frameData:(NSData *)frameData;
+- (void)receivedFrameWithSize:(NSSize)size timestamp:(uint64_t)timestamp fpsNumerator:(uint32_t)fpsNumerator fpsDenominator:(uint32_t)fpsDenominator frameData:(NSData *)frameData;
 - (void)receivedStop;
 
 @end

--- a/src/dal-plugin/MachClient.mm
+++ b/src/dal-plugin/MachClient.mm
@@ -84,7 +84,7 @@
             break;
         case MachMsgIdFrame:
             VLog(@"Received frame message");
-            if (components.count == 4) {
+            if (components.count >= 6) {
                 CGFloat width;
                 [components[0] getBytes:&width length:sizeof(width)];
                 CGFloat height;
@@ -92,7 +92,12 @@
                 uint64_t timestamp;
                 [components[2] getBytes:&timestamp length:sizeof(timestamp)];
                 VLog(@"Received frame data: %fx%f (%llu)", width, height, timestamp);
-                [self.delegate receivedFrameWithSize:NSMakeSize(width, height) timestamp:timestamp frameData:components[3]];
+                NSData *frameData = components[3];
+                uint32_t fpsNumerator;
+                [components[4] getBytes:&fpsNumerator length:sizeof(fpsNumerator)];
+                uint32_t fpsDenominator;
+                [components[5] getBytes:&fpsDenominator length:sizeof(fpsDenominator)];
+                [self.delegate receivedFrameWithSize:NSMakeSize(width, height) timestamp:timestamp fpsNumerator:fpsNumerator fpsDenominator:fpsDenominator frameData:frameData];
             }
             break;
         case MachMsgIdStop:

--- a/src/dal-plugin/PlugIn.mm
+++ b/src/dal-plugin/PlugIn.mm
@@ -172,7 +172,7 @@ typedef enum {
 
 #pragma mark - MachClientDelegate
 
-- (void)receivedFrameWithSize:(NSSize)size timestamp:(uint64_t)timestamp frameData:(nonnull NSData *)frameData {
+- (void)receivedFrameWithSize:(NSSize)size timestamp:(uint64_t)timestamp fpsNumerator:(uint32_t)fpsNumerator fpsDenominator:(uint32_t)fpsDenominator frameData:(NSData *)frameData {
     dispatch_sync(_stateQueue, ^{
         if (_state == PlugInStateWaitingForServer) {
             dispatch_suspend(_machConnectTimer);
@@ -185,7 +185,7 @@ typedef enum {
     // Add 5 more seconds onto the timeout timer
     dispatch_source_set_timer(_timeoutTimer, dispatch_time(DISPATCH_TIME_NOW, 5.0 * NSEC_PER_SEC), 5.0 * NSEC_PER_SEC, (1ull * NSEC_PER_SEC) / 10);
 
-    [self.stream queueFrameWithSize:size timestamp:timestamp frameData:frameData];
+    [self.stream queueFrameWithSize:size timestamp:timestamp fpsNumerator:fpsNumerator fpsDenominator:fpsDenominator frameData:frameData];
 }
 
 - (void)receivedStop {

--- a/src/dal-plugin/Stream.h
+++ b/src/dal-plugin/Stream.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)stopServingDefaultFrames;
 
-- (void)queueFrameWithSize:(NSSize)size timestamp:(uint64_t)timestamp frameData:(NSData *)frameData;
+- (void)queueFrameWithSize:(NSSize)size timestamp:(uint64_t)timestamp fpsNumerator:(uint32_t)fpsNumerator fpsDenominator:(uint32_t)fpsDenominator frameData:(NSData *)frameData;
 
 @end
 

--- a/src/dal-plugin/Stream.mm
+++ b/src/dal-plugin/Stream.mm
@@ -169,7 +169,7 @@
     CVPixelBufferRef pixelBuffer = [self createPixelBufferWithTestAnimation];
 
     uint64_t hostTime = mach_absolute_time();
-    CMSampleTimingInfo timingInfo = CMSampleTimingInfoForTimestamp(hostTime, FPS);
+    CMSampleTimingInfo timingInfo = CMSampleTimingInfoForTimestamp(hostTime, FPS, 1);
 
     OSStatus err = CMIOStreamClockPostTimingEvent(timingInfo.presentationTimeStamp, hostTime, true, self.clock);
     if (err != noErr) {
@@ -205,14 +205,14 @@
     }
 }
 
-- (void)queueFrameWithSize:(NSSize)size timestamp:(uint64_t)timestamp frameData:(NSData *)frameData {
+- (void)queueFrameWithSize:(NSSize)size timestamp:(uint64_t)timestamp fpsNumerator:(uint32_t)fpsNumerator fpsDenominator:(uint32_t)fpsDenominator frameData:(NSData *)frameData {
     if (CMSimpleQueueGetFullness(self.queue) >= 1.0) {
         DLog(@"Queue is full, bailing out");
         return;
     }
     OSStatus err = noErr;
 
-    CMSampleTimingInfo timingInfo = CMSampleTimingInfoForTimestamp(timestamp, FPS);
+    CMSampleTimingInfo timingInfo = CMSampleTimingInfoForTimestamp(timestamp, fpsNumerator, fpsDenominator);
 
     err = CMIOStreamClockPostTimingEvent(timingInfo.presentationTimeStamp, mach_absolute_time(), true, self.clock);
     if (err != noErr) {

--- a/src/obs-plugin/MachServer.h
+++ b/src/obs-plugin/MachServer.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*!
  Will eventually be used for sending frames to all connected clients
  */
-- (void)sendFrameWithSize:(NSSize)size timestamp:(uint64_t)timestamp frameBytes:(uint8_t *)frameData;
+- (void)sendFrameWithSize:(NSSize)size timestamp:(uint64_t)timestamp fpsNumerator:(uint32_t)fpsNumerator fpsDenominator:(uint32_t)fpsDenominator frameBytes:(uint8_t *)frameBytes;
 
 - (void)stop;
 

--- a/src/obs-plugin/MachServer.mm
+++ b/src/obs-plugin/MachServer.mm
@@ -102,7 +102,7 @@
     [self.clientPorts minusSet:removedPorts];
 }
 
-- (void)sendFrameWithSize:(NSSize)size timestamp:(uint64_t)timestamp frameBytes:(uint8_t *)frameBytes {
+- (void)sendFrameWithSize:(NSSize)size timestamp:(uint64_t)timestamp fpsNumerator:(uint32_t)fpsNumerator fpsDenominator:(uint32_t)fpsDenominator frameBytes:(uint8_t *)frameBytes {
     if ([self.clientPorts count] <= 0) {
         return;
     }
@@ -113,13 +113,16 @@
         CGFloat height = size.height;
         NSData *heightData = [NSData dataWithBytes:&height length:sizeof(height)];
         NSData *timestampData = [NSData dataWithBytes:&timestamp length:sizeof(timestamp)];
+        NSData *fpsNumeratorData = [NSData dataWithBytes:&fpsNumerator length:sizeof(fpsNumerator)];
+        NSData *fpsDenominatorData = [NSData dataWithBytes:&fpsDenominator length:sizeof(fpsDenominator)];
+
         // NOTE: I'm not totally sure about the safety of dataWithBytesNoCopy in this context.
         // Seems like there could potentially be an issue if the frameBuffer went away before the
         // mach message finished sending. But it seems to be working and avoids a memory copy. Alternately
         // we could do something like
         // NSData *frameData = [NSData dataWithBytes:(void *)frameBytes length:size.width * size.height * 2];
         NSData *frameData = [NSData dataWithBytesNoCopy:(void *)frameBytes length:size.width * size.height * 2 freeWhenDone:NO];
-        [self sendMessageToClientsWithMsgId:MachMsgIdFrame components:@[widthData, heightData, timestampData, frameData]];
+        [self sendMessageToClientsWithMsgId:MachMsgIdFrame components:@[widthData, heightData, timestampData, frameData, fpsNumeratorData, fpsDenominatorData]];
     }
 }
 


### PR DESCRIPTION
This patch sends FPS from OBS to the DAL plugin with every frame. A couple thoughts about this change:

* I was unsure whether to send FPS as a `double`/`CGFloat` or as numerator/denominator integers. OBS uses numerator/denominator integers and there's probably a good reason for that, so that's what I stuck with.

* Technically I don't need to send resolution and fps on every frame. I could send it only at the start of the stream from OBS. But that adds some amount of complexity to the code and I figure adding ~24 extra bytes of overhead on top of 1,843,200 bytes for the framebuffer (at 720p) is not a big deal at all. I think it's more important to keep the code simple.