### PR TITLE
Multiple test card resolutions

### DIFF
--- a/src/dal-plugin/PlugIn.h
+++ b/src/dal-plugin/PlugIn.h
@@ -24,6 +24,9 @@
 #import "MachClient.h"
 #import "Stream.h"
 
+#define kTestCardWidthKey @"obs-mac-virtualcam-test-card-width"
+#define kTestCardHeightKey @"obs-mac-virtualcam-test-card-height"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface PlugIn : NSObject <CMIOObject>

--- a/src/dal-plugin/PlugIn.mm
+++ b/src/dal-plugin/PlugIn.mm
@@ -175,11 +175,11 @@ typedef enum {
 - (void)receivedFrameWithSize:(NSSize)size timestamp:(uint64_t)timestamp frameData:(nonnull NSData *)frameData {
     dispatch_sync(_stateQueue, ^{
         if (_state == PlugInStateWaitingForServer) {
-            NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-            [defaults setInteger:size.width forKey:@"obs-virtualcam-dal-width"];
-            [defaults setInteger:size.height forKey:@"obs-virtualcam-dal-height"];
-            [defaults synchronize];
-            
+            dispatch_async(dispatch_get_main_queue(), ^{
+                NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+                [defaults setInteger:size.width forKey:kTestCardWidthKey];
+                [defaults setInteger:size.height forKey:kTestCardHeightKey];
+            });
             dispatch_suspend(_machConnectTimer);
             [self.stream stopServingDefaultFrames];
             dispatch_resume(_timeoutTimer);

--- a/src/dal-plugin/PlugIn.mm
+++ b/src/dal-plugin/PlugIn.mm
@@ -175,6 +175,11 @@ typedef enum {
 - (void)receivedFrameWithSize:(NSSize)size timestamp:(uint64_t)timestamp frameData:(nonnull NSData *)frameData {
     dispatch_sync(_stateQueue, ^{
         if (_state == PlugInStateWaitingForServer) {
+            NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+            [defaults setInteger:size.width forKey:@"obs-virtualcam-dal-width"];
+            [defaults setInteger:size.height forKey:@"obs-virtualcam-dal-height"];
+            [defaults synchronize];
+            
             dispatch_suspend(_machConnectTimer);
             [self.stream stopServingDefaultFrames];
             dispatch_resume(_timeoutTimer);

--- a/src/dal-plugin/PlugIn.mm
+++ b/src/dal-plugin/PlugIn.mm
@@ -175,11 +175,10 @@ typedef enum {
 - (void)receivedFrameWithSize:(NSSize)size timestamp:(uint64_t)timestamp frameData:(nonnull NSData *)frameData {
     dispatch_sync(_stateQueue, ^{
         if (_state == PlugInStateWaitingForServer) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-                [defaults setInteger:size.width forKey:kTestCardWidthKey];
-                [defaults setInteger:size.height forKey:kTestCardHeightKey];
-            });
+            NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+            [defaults setInteger:size.width forKey:kTestCardWidthKey];
+            [defaults setInteger:size.height forKey:kTestCardHeightKey];
+            
             dispatch_suspend(_machConnectTimer);
             [self.stream stopServingDefaultFrames];
             dispatch_resume(_timeoutTimer);

--- a/src/dal-plugin/Stream.mm
+++ b/src/dal-plugin/Stream.mm
@@ -40,6 +40,7 @@
 @property (readonly) CFTypeRef clock;
 @property UInt64 sequenceNumber;
 @property (readonly) NSImage *testCardImage;
+@property NSSize testCardSize;
 
 @end
 
@@ -78,6 +79,8 @@
 
 - (void)startServingDefaultFrames {
     DLogFunc(@"");
+    _testCardImage = nil;
+    _testCardSize.height = 0;
     dispatch_resume(_frameDispatchSource);
 }
 
@@ -107,9 +110,20 @@
     return _clock;
 }
 
+- (NSSize)testCardImageSize {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    int width = [[defaults objectForKey:@"obs-virtualcam-dal-width"] integerValue];
+    int height = [[defaults objectForKey:@"obs-virtualcam-dal-height"] integerValue];
+    DLog("Calling testCardImageSize");
+    if(width==0 || height==0){
+        return NSMakeSize(1280, 720);
+    }
+    return NSMakeSize(width, height);
+}
+
 - (NSImage *)testCardImage {
     if (_testCardImage == nil) {
-        _testCardImage = ImageOfTestCardWithSize(NSMakeSize(1280, 720));
+        _testCardImage = ImageOfTestCardWithSize([self testCardImageSize]);
     }
     return _testCardImage;
 }
@@ -125,8 +139,12 @@
 }
 
 - (CVPixelBufferRef)createPixelBufferWithTestAnimation {
-    int width = 1280;
-    int height = 720;
+    
+    if (self.testCardSize.height == 0){
+        self.testCardSize = [self testCardImageSize];
+    }
+    int width = self.testCardSize.width;
+    int height = self.testCardSize.height;
 
     NSDictionary *options = [NSDictionary dictionaryWithObjectsAndKeys:
                              [NSNumber numberWithBool:YES], kCVPixelBufferCGImageCompatibilityKey,

--- a/src/dal-plugin/Stream.mm
+++ b/src/dal-plugin/Stream.mm
@@ -41,7 +41,7 @@
 @property (readonly) CFTypeRef clock;
 @property UInt64 sequenceNumber;
 @property (readonly) NSImage *testCardImage;
-@property NSSize testCardSize;
+@property (nonatomic) NSSize testCardSize;
 
 @end
 
@@ -111,7 +111,7 @@
     return _clock;
 }
 
-- (NSSize)testCardImageSize {
+- (NSSize)testCardSize {
     if (NSEqualSizes(_testCardSize, NSZeroSize)) {
         NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
         int width = [[defaults objectForKey:kTestCardWidthKey] integerValue];
@@ -127,7 +127,7 @@
 
 - (NSImage *)testCardImage {
     if (_testCardImage == nil) {
-        _testCardImage = ImageOfTestCardWithSize([self testCardImageSize]);
+        _testCardImage = ImageOfTestCardWithSize([self testCardSize]);
     }
     return _testCardImage;
 }
@@ -143,10 +143,7 @@
 }
 
 - (CVPixelBufferRef)createPixelBufferWithTestAnimation {
-    
-    if (NSEqualSizes(self.testCardSize, NSZeroSize)){
-        self.testCardSize = [self testCardImageSize];
-    }
+    self.testCardSize = [self testCardSize];
     int width = self.testCardSize.width;
     int height = self.testCardSize.height;
 

--- a/src/dal-plugin/Stream.mm
+++ b/src/dal-plugin/Stream.mm
@@ -26,6 +26,7 @@
 #import "Logging.h"
 #import "CMSampleBufferUtils.h"
 #import "TestCard.h"
+#import "PlugIn.h"
 
 @interface Stream () {
     CMSimpleQueueRef _queue;
@@ -80,7 +81,7 @@
 - (void)startServingDefaultFrames {
     DLogFunc(@"");
     _testCardImage = nil;
-    _testCardSize.height = 0;
+    _testCardSize = NSZeroSize;
     dispatch_resume(_frameDispatchSource);
 }
 
@@ -111,13 +112,17 @@
 }
 
 - (NSSize)testCardImageSize {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    int width = [[defaults objectForKey:@"obs-virtualcam-dal-width"] integerValue];
-    int height = [[defaults objectForKey:@"obs-virtualcam-dal-height"] integerValue];
-    if(width==0 || height==0){
-        return NSMakeSize(1280, 720);
+    if (NSEqualSizes(_testCardSize, NSZeroSize)) {
+        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+        int width = [[defaults objectForKey:kTestCardWidthKey] integerValue];
+        int height = [[defaults objectForKey:kTestCardHeightKey] integerValue];
+        if( width == 0 || height == 0) {
+            _testCardSize = NSMakeSize(1280, 720);
+        } else {
+            _testCardSize = NSMakeSize(width, height);
+        }
     }
-    return NSMakeSize(width, height);
+    return _testCardSize;
 }
 
 - (NSImage *)testCardImage {
@@ -139,7 +144,7 @@
 
 - (CVPixelBufferRef)createPixelBufferWithTestAnimation {
     
-    if (self.testCardSize.height == 0){
+    if (NSEqualSizes(self.testCardSize, NSZeroSize)){
         self.testCardSize = [self testCardImageSize];
     }
     int width = self.testCardSize.width;

--- a/src/dal-plugin/Stream.mm
+++ b/src/dal-plugin/Stream.mm
@@ -114,7 +114,6 @@
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     int width = [[defaults objectForKey:@"obs-virtualcam-dal-width"] integerValue];
     int height = [[defaults objectForKey:@"obs-virtualcam-dal-height"] integerValue];
-    DLog("Calling testCardImageSize");
     if(width==0 || height==0){
         return NSMakeSize(1280, 720);
     }

--- a/src/dal-plugin/Stream.mm
+++ b/src/dal-plugin/Stream.mm
@@ -127,7 +127,7 @@
 
 - (NSImage *)testCardImage {
     if (_testCardImage == nil) {
-        _testCardImage = ImageOfTestCardWithSize([self testCardSize]);
+        _testCardImage = ImageOfTestCardWithSize(self.testCardSize);
     }
     return _testCardImage;
 }
@@ -143,7 +143,6 @@
 }
 
 - (CVPixelBufferRef)createPixelBufferWithTestAnimation {
-    self.testCardSize = [self testCardSize];
     int width = self.testCardSize.width;
     int height = self.testCardSize.height;
 


### PR DESCRIPTION
The test card now remembers the last OBS setting sent and will adapt it's resolution accordingly.
TODO: The test card doesn't scale that well (see below). Image drawing (TestCard.mm) needs to be changed for this. If this is considered mandatory for this PR to be merged, I'll happily convert it to a draft.
Solves #130.

Regular:
<img width="1280" alt="Bildschirmfoto 2020-05-28 um 00 06 26" src="https://user-images.githubusercontent.com/59806498/83077169-25907d00-a077-11ea-9e36-52536d572b36.png">
Scaled to 1080p:
<img width="1880" alt="Bildschirmfoto 2020-05-28 um 00 06 07" src="https://user-images.githubusercontent.com/59806498/83077171-26c1aa00-a077-11ea-8059-360c1e1796f0.png">
