### PR TITLE
Advertise recent FPS in CMVideoFormatDescription

### DIFF
--- a/src/dal-plugin/PlugIn.h
+++ b/src/dal-plugin/PlugIn.h
@@ -26,6 +26,7 @@
 
 #define kTestCardWidthKey @"obs-mac-virtualcam-test-card-width"
 #define kTestCardHeightKey @"obs-mac-virtualcam-test-card-height"
+#define kTestCardFPSKey @"obs-mac-virtualcam-test-card-fps"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/src/dal-plugin/PlugIn.mm
+++ b/src/dal-plugin/PlugIn.mm
@@ -178,7 +178,8 @@ typedef enum {
             NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
             [defaults setInteger:size.width forKey:kTestCardWidthKey];
             [defaults setInteger:size.height forKey:kTestCardHeightKey];
-            
+            [defaults setDouble:(double)fpsNumerator/(double)fpsDenominator forKey:kTestCardFPSKey];
+
             dispatch_suspend(_machConnectTimer);
             [self.stream stopServingDefaultFrames];
             dispatch_resume(_timeoutTimer);


### PR DESCRIPTION
This change makes it so the test card matches the most recent framerate sent from obs (like we do for width/height in #149). This _might_ help apps that are sensitive to incorrect `CMVideoFormatDescription`s (e.g. perhaps they use the initial format description to set up their player timing and then don't ever update it)