### PR TITLE
FIX: control reaches end of non-void function

### DIFF
--- a/src/obs-plugin/plugin-main.mm
+++ b/src/obs-plugin/plugin-main.mm
@@ -28,10 +28,14 @@ static const char *virtualcam_output_get_name(void *type_data)
     return obs_module_text("macOS Virtual Webcam");
 }
 
+static void *data = &data;
+
 static void *virtualcam_output_create(obs_data_t *settings, obs_output_t *output)
 {
     blog(LOG_DEBUG, "output_create");
     sMachServer = [[MachServer alloc] init];
+    // `obs_output_info.create` should return non `NULL` pointer.
+    return data;
 }
 
 static void virtualcam_output_destroy(void *data)

--- a/src/obs-plugin/plugin-main.mm
+++ b/src/obs-plugin/plugin-main.mm
@@ -28,13 +28,13 @@ static const char *virtualcam_output_get_name(void *type_data)
     return obs_module_text("macOS Virtual Webcam");
 }
 
+// This is a dummy pointer so we have something to return from virtualcam_output_create
 static void *data = &data;
 
 static void *virtualcam_output_create(obs_data_t *settings, obs_output_t *output)
 {
     blog(LOG_DEBUG, "output_create");
     sMachServer = [[MachServer alloc] init];
-    // `obs_output_info.create` should return non `NULL` pointer.
     return data;
 }
 


### PR DESCRIPTION
**Problem**

`virtualcam_output_create` is expected to return `void *` data
associated to the output but it has no `return`.
In fact, `obs_output_info.create` should return non `NULL` pointer
or it will not work.

**Solution**

Add static dummy self-pointer and return it.
Non of output code is using associated `data` for now.