### PR TITLE
Try to fix the OBS build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         cd obs-studio/build
 
         export QTDIR=$(brew --prefix qt5)
-        cmake ..
+        cmake -DDISABLE_PYTHON=ON ..
         make -j
 
     - name: Install obs-mac-virtualcam deps


### PR DESCRIPTION
The errors look like this:

```
[ 72%] Linking CXX shared library libobs-scripting.dylib
Undefined symbols for architecture x86_64:
  "__Py_Dealloc", referenced from:
      _py_to_libobs_ in obs-scripting-python.c.o
      _libobs_to_py_ in obs-scripting-python.c.o
      _add_functions_to_py_module in obs-scripting-python.c.o
      _add_to_python_path in obs-scripting-python.c.o
      _load_python_script in obs-scripting-python.c.o
      _obs_python_script_update in obs-scripting-python.c.o
      _obs_python_script_unload in obs-scripting-python.c.o
      ...
ld: symbol(s) not found for architecture x86_64
```

I noticed in the OBS [build instructions](https://obsproject.com/wiki/install-instructions) there's this python-related cmake flag that I don't think was there before:

```
cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13 -DDISABLE_PYTHON=ON ..
```

It'd be more consistent to instead use an environment variable for this (like we do for `MACOSX_DEPLOYMENT_TARGET` and `QTDIR`). But I'm not 100% that will work and I want to try out https://github.com/obsproject/obs-studio/pull/3492.