### PR TITLE
Try to use `CVPixelBufferGetBaseAddressOfPlane`

### DIFF
--- a/src/dal-plugin/CMSampleBufferUtils.mm
+++ b/src/dal-plugin/CMSampleBufferUtils.mm
@@ -35,7 +35,7 @@ OSStatus CMSampleBufferCreateFromData(NSSize size, CMSampleTimingInfo timingInfo
 
     // Copy memory into the pixel buffer
     CVPixelBufferLockBaseAddress(pixelBuffer, 0);
-    uint8_t *dest = (uint8_t *)CVPixelBufferGetBaseAddress(pixelBuffer);
+    uint8_t *dest = (uint8_t *)CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 0);
     uint8_t *src = (uint8_t *)data.bytes;
 
     size_t destBytesPerRow = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 0);


### PR DESCRIPTION
This change uses `CVPixelBufferGetBaseAddressOfPlane` instead of `CVPixelBufferGetBaseAddress` to get the base memory address to copy the framebuffer into. Hopefully this will fix the intermittent skewed output bug in johnboiles/obs-mac-virtualcam#160.

I've never been able to reproduce this personally so I can't validate this fix. But it seems like the _more right_ API to use. 🤞

Assuming https://github.com/johnboiles/obs-mac-virtualcam/pull/229 fixed the build, the build on this PR should produce a signed pkg we can use to test this change.