### PR TITLE
[Needs testers] Support for DAL plugin built as a universal binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: 10.13
       MACOS_DEPS_VERSION: '2020-08-30'
       QT_VERSION: '5.14.1'
-      CPATH: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/
+      CPATH: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include
       obs-studio-ref: 26.0.2
     runs-on: macos-latest
 
@@ -101,7 +101,7 @@ jobs:
         mkdir obs-mac-virtualcam/build
         cd obs-mac-virtualcam/build
 
-        cmake -DCMAKE_C_COMPILER "/usr/bin/clang" -DLIBOBS_INCLUDE_DIR:STRING=$GITHUB_WORKSPACE/obs-studio/libobs \
+        cmake -DLIBOBS_INCLUDE_DIR:STRING=$GITHUB_WORKSPACE/obs-studio/libobs \
           -DLIBOBS_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/libobs/libobs.dylib \
           -DOBS_FRONTEND_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/UI/obs-frontend-api/libobs-frontend-api.dylib \
           -DQTDIR:STRING=/tmp/obsdeps -D CMAKE_OSX_ARCHITECTURES="arm64;x86_64" ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
       MACOS_DEPS_VERSION: '2020-08-30'
       QT_VERSION: '5.14.1'
       obs-studio-ref: 26.0.2
-    runs-on: macos-latest
+    runs-on: macos-11.0
 
     steps:
-    - name: Use cmake
+    - name: Update cmake
       run: |
         cmake --version
         brew update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
         cmake -DLIBOBS_INCLUDE_DIR:STRING=$GITHUB_WORKSPACE/obs-studio/libobs \
           -DLIBOBS_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/libobs/libobs.dylib \
           -DOBS_FRONTEND_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/UI/obs-frontend-api/libobs-frontend-api.dylib \
-          -DQTDIR:STRING=/tmp/obsdeps -D CMAKE_OSX_ARCHITECTURES="x86_64" ..
+          -DQTDIR:STRING=/tmp/obsdeps -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" ..
 
         make -j dal-plugin
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
     - name: Use cmake
       run: |
         cmake --version
+        brew update
         brew upgrade cmake
         cmake --version
 
@@ -92,6 +93,7 @@ jobs:
       run: |
         mkdir obs-mac-virtualcam/build
         cd obs-mac-virtualcam/build
+        echo $PWD
 
         cmake -DLIBOBS_INCLUDE_DIR:STRING=$GITHUB_WORKSPACE/obs-studio/libobs \
           -DLIBOBS_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/libobs/libobs.dylib \
@@ -105,6 +107,7 @@ jobs:
         rm -rf obs-mac-virtualcam/build
         mkdir obs-mac-virtualcam/build
         cd obs-mac-virtualcam/build
+        echo $PWD
 
         cmake -DLIBOBS_INCLUDE_DIR:STRING=$GITHUB_WORKSPACE/obs-studio/libobs \
           -DLIBOBS_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/libobs/libobs.dylib \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     env:
-      MACOSX_DEPLOYMENT_TARGET: 10.13
+      MACOSX_DEPLOYMENT_TARGET: 10.15
       MACOS_DEPS_VERSION: '2020-08-30'
       QT_VERSION: '5.14.1'
       obs-studio-ref: 26.0.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       MACOS_DEPS_VERSION: '2020-08-30'
       QT_VERSION: '5.14.1'
       obs-studio-ref: 26.0.2
-    runs-on: macos-latest
+    runs-on: macos-11.0
 
     steps:
     - name: Checkout obs-mac-virtualcam

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,12 @@ on:
 jobs:
   build:
     env:
-      MACOSX_DEPLOYMENT_TARGET: 10.15
+      MACOSX_DEPLOYMENT_TARGET: 10.13
       MACOS_DEPS_VERSION: '2020-08-30'
       QT_VERSION: '5.14.1'
+      CPATH: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/
       obs-studio-ref: 26.0.2
-    runs-on: macos-11.0
+    runs-on: macos-latest
 
     steps:
     - name: Checkout obs-mac-virtualcam
@@ -100,7 +101,7 @@ jobs:
         mkdir obs-mac-virtualcam/build
         cd obs-mac-virtualcam/build
 
-        cmake -DLIBOBS_INCLUDE_DIR:STRING=$GITHUB_WORKSPACE/obs-studio/libobs \
+        cmake -DCMAKE_C_COMPILER "/usr/bin/clang" -DLIBOBS_INCLUDE_DIR:STRING=$GITHUB_WORKSPACE/obs-studio/libobs \
           -DLIBOBS_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/libobs/libobs.dylib \
           -DOBS_FRONTEND_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/UI/obs-frontend-api/libobs-frontend-api.dylib \
           -DQTDIR:STRING=/tmp/obsdeps -D CMAKE_OSX_ARCHITECTURES="arm64;x86_64" ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,16 +16,9 @@ jobs:
       MACOS_DEPS_VERSION: '2020-08-30'
       QT_VERSION: '5.14.1'
       obs-studio-ref: 26.0.2
-    runs-on: macos-11.0
+    runs-on: macos-latest
 
     steps:
-    - name: Update cmake
-      run: |
-        cmake --version
-        brew update
-        brew upgrade cmake
-        cmake --version
-
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
@@ -97,7 +90,6 @@ jobs:
       run: |
         mkdir obs-mac-virtualcam/build
         cd obs-mac-virtualcam/build
-        echo $PWD
 
         cmake -DLIBOBS_INCLUDE_DIR:STRING=$GITHUB_WORKSPACE/obs-studio/libobs \
           -DLIBOBS_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/libobs/libobs.dylib \
@@ -108,10 +100,7 @@ jobs:
 
     - name: Build the DAL plugin
       run: |
-        rm -rf obs-mac-virtualcam/build
-        mkdir obs-mac-virtualcam/build
         cd obs-mac-virtualcam/build
-        echo $PWD
 
         cmake -DLIBOBS_INCLUDE_DIR:STRING=$GITHUB_WORKSPACE/obs-studio/libobs \
           -DLIBOBS_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/libobs/libobs.dylib \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: macos-latest
 
     steps:
+    - name: Use cmake
+      run: cmake --version
+
     - name: Checkout obs-mac-virtualcam
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         cmake -DQTDIR="/tmp/obsdeps" -DSWIGDIR="/tmp/obsdeps" -DDepsPath="/tmp/obsdeps" -DDISABLE_PYTHON=ON ..
         make -j
 
-    - name: Build the plugin
+    - name: Build the OBS plugin
       run: |
         mkdir obs-mac-virtualcam/build
         cd obs-mac-virtualcam/build
@@ -92,7 +92,20 @@ jobs:
           -DOBS_FRONTEND_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/UI/obs-frontend-api/libobs-frontend-api.dylib \
           -DQTDIR:STRING=/tmp/obsdeps ..
 
-        make -j
+        make -j obs-plugin
+
+    - name: Build the DAL plugin
+      run: |
+        rm -rf obs-mac-virtualcam/build
+        mkdir obs-mac-virtualcam/build
+        cd obs-mac-virtualcam/build
+
+        cmake -DLIBOBS_INCLUDE_DIR:STRING=$GITHUB_WORKSPACE/obs-studio/libobs \
+          -DLIBOBS_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/libobs/libobs.dylib \
+          -DOBS_FRONTEND_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/UI/obs-frontend-api/libobs-frontend-api.dylib \
+          -DQTDIR:STRING=/tmp/obsdeps -D CMAKE_OSX_ARCHITECTURES="arm64;x86_64" ..
+
+        make -j dal-plugin
 
     - name: Fix runtime QT deps
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,8 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: 10.13
       MACOS_DEPS_VERSION: '2020-08-30'
       QT_VERSION: '5.14.1'
-      CPATH: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include
+      CPATH: '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include'
+      LIBRARY_PATH: '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib:/opt/local/lib'
       obs-studio-ref: 26.0.2
     runs-on: macos-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
         cmake -DLIBOBS_INCLUDE_DIR:STRING=$GITHUB_WORKSPACE/obs-studio/libobs \
           -DLIBOBS_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/libobs/libobs.dylib \
           -DOBS_FRONTEND_LIB:STRING=$GITHUB_WORKSPACE/obs-studio/build/UI/obs-frontend-api/libobs-frontend-api.dylib \
-          -DQTDIR:STRING=/tmp/obsdeps -D CMAKE_OSX_ARCHITECTURES="arm64;x86_64" ..
+          -DQTDIR:STRING=/tmp/obsdeps -D CMAKE_OSX_ARCHITECTURES="x86_64" ..
 
         make -j dal-plugin
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,10 @@ jobs:
         brew upgrade cmake
         cmake --version
 
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+
     - name: Checkout obs-mac-virtualcam
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,14 +15,15 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: 10.13
       MACOS_DEPS_VERSION: '2020-08-30'
       QT_VERSION: '5.14.1'
-      CPATH: '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include'
-      LIBRARY_PATH: '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib:/opt/local/lib'
       obs-studio-ref: 26.0.2
     runs-on: macos-latest
 
     steps:
     - name: Use cmake
-      run: cmake --version
+      run: |
+        cmake --version
+        brew upgrade cmake
+        cmake --version
 
     - name: Checkout obs-mac-virtualcam
       uses: actions/checkout@v2


### PR DESCRIPTION
This change separates out the dal-plugin build from x86-only obs-plugin build so that the dal-plugin can work on M1 Macs in universal applications.