### PR TITLE
Try to fix crash related to CMSimpleQueueCreate

### DIFF
--- a/src/dal-plugin/Stream.mm
+++ b/src/dal-plugin/Stream.mm
@@ -133,7 +133,7 @@
     if (_fps == 0) {
         NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
         double fps = [[defaults objectForKey:kTestCardFPSKey] doubleValue];
-        if (fps == 0) {
+        if (isnan(fps) || fps <= 0 || fps > 120) {
             _fps = DEFAULT_FPS;
         } else {
             _fps = fps;


### PR DESCRIPTION
Add more validation around the FPS value loaded from NSUserDefaults. See #233 and #228. Even if this doesn't fix the crash it's probably the right thing to do.